### PR TITLE
Variable redeclared and lost

### DIFF
--- a/win32.cpp
+++ b/win32.cpp
@@ -40,7 +40,7 @@ namespace neosmart
 			uint64_t rounds = milliseconds / waitUnit;
 			uint32_t remainder = milliseconds % waitUnit;
 
-			uint32_t result = WaitForSingleObject(handle, remainder);
+			result = WaitForSingleObject(handle, remainder);
 			while (result == WAIT_TIMEOUT && rounds-- != 0)
 			{
 				result = WaitForSingleObject(handle, waitUnit);


### PR DESCRIPTION
`result` is already declared. By defining another variable inside of a scope you're not modifying the original variable.