### PR TITLE
Fix local variable shadow in WaitForMultipleEvents

### DIFF
--- a/src/pevents.cpp
+++ b/src/pevents.cpp
@@ -571,7 +571,7 @@ namespace neosmart {
             uint64_t rounds = milliseconds / waitUnit;
             uint32_t remainder = milliseconds % waitUnit;
 
-            uint32_t result = WaitForMultipleObjects(count, handles, waitAll, remainder);
+            result = WaitForMultipleObjects(count, handles, waitAll, remainder);
             while (result == WAIT_TIMEOUT && rounds-- != 0) {
                 result = WaitForMultipleObjects(count, handles, waitAll, waitUnit);
             }


### PR DESCRIPTION
This fixes a bug where `WaitForMultipleEvents` on Windows would indicate the wrong event was signaled if `milliseconds` was greater than `UINT32_MAX`. It was caused by the local variable `result`, which is used to set `index` and the return value being shadowed inside the `else` case for large timeouts. 