### PR TITLE
Fix C4146 Compiler Warnings

### DIFF
--- a/src/pevents.cpp
+++ b/src/pevents.cpp
@@ -120,7 +120,7 @@ namespace neosmart {
             }
 
             timespec ts;
-            if (milliseconds != UINT64_MAX) {
+            if (milliseconds != INFINITE_WAIT) {
                 timeval tv;
                 gettimeofday(&tv, NULL);
 
@@ -134,7 +134,7 @@ namespace neosmart {
             do {
                 // Regardless of whether it's an auto-reset or manual-reset event:
                 // wait to obtain the event, then lock anyone else out
-                if (milliseconds != UINT64_MAX) {
+                if (milliseconds != INFINITE_WAIT) {
                     result = pthread_cond_timedwait(&event->CVariable, &event->Mutex, &ts);
                 } else {
                     result = pthread_cond_wait(&event->CVariable, &event->Mutex);
@@ -264,7 +264,7 @@ namespace neosmart {
             if (milliseconds == 0) {
                 result = WAIT_TIMEOUT;
                 done = true;
-            } else if (milliseconds != UINT64_MAX) {
+            } else if (milliseconds != INFINITE_WAIT) {
                 timeval tv;
                 gettimeofday(&tv, NULL);
 
@@ -286,7 +286,7 @@ namespace neosmart {
                    (!waitAll && wfmo->Status.FiredEvent != -1);
 
             if (!done) {
-                if (milliseconds != UINT64_MAX) {
+                if (milliseconds != INFINITE_WAIT) {
                     result = pthread_cond_timedwait(&wfmo->CVariable, &wfmo->Mutex, &ts);
                 } else {
                     result = pthread_cond_wait(&wfmo->CVariable, &wfmo->Mutex);
@@ -513,7 +513,7 @@ namespace neosmart {
         HANDLE handle = static_cast<HANDLE>(event);
 
         // WaitForSingleObject(Ex) and WaitForMultipleObjects(Ex) only support 32-bit timeout
-        if (milliseconds == UINT64_MAX || (milliseconds >> 32) == 0) {
+        if (milliseconds == INFINITE_WAIT || (milliseconds >> 32) == 0) {
             result = WaitForSingleObject(handle, static_cast<uint32_t>(milliseconds));
         } else {
             // Cannot wait for 0xFFFFFFFF because that means infinity to WIN32
@@ -562,7 +562,7 @@ namespace neosmart {
         uint32_t result = 0;
 
         // WaitForSingleObject(Ex) and WaitForMultipleObjects(Ex) only support 32-bit timeout
-        if (milliseconds == UINT64_MAX || (milliseconds >> 32) == 0) {
+        if (milliseconds == INFINITE_WAIT || (milliseconds >> 32) == 0) {
             result = WaitForMultipleObjects(count, handles, waitAll,
                                             static_cast<uint32_t>(milliseconds));
         } else {

--- a/src/pevents.cpp
+++ b/src/pevents.cpp
@@ -120,7 +120,7 @@ namespace neosmart {
             }
 
             timespec ts;
-            if (milliseconds != -1ul) {
+            if (milliseconds != UINT64_MAX) {
                 timeval tv;
                 gettimeofday(&tv, NULL);
 
@@ -134,7 +134,7 @@ namespace neosmart {
             do {
                 // Regardless of whether it's an auto-reset or manual-reset event:
                 // wait to obtain the event, then lock anyone else out
-                if (milliseconds != -1ul) {
+                if (milliseconds != UINT64_MAX) {
                     result = pthread_cond_timedwait(&event->CVariable, &event->Mutex, &ts);
                 } else {
                     result = pthread_cond_wait(&event->CVariable, &event->Mutex);
@@ -264,7 +264,7 @@ namespace neosmart {
             if (milliseconds == 0) {
                 result = WAIT_TIMEOUT;
                 done = true;
-            } else if (milliseconds != -1ul) {
+            } else if (milliseconds != UINT64_MAX) {
                 timeval tv;
                 gettimeofday(&tv, NULL);
 
@@ -286,7 +286,7 @@ namespace neosmart {
                    (!waitAll && wfmo->Status.FiredEvent != -1);
 
             if (!done) {
-                if (milliseconds != -1ul) {
+                if (milliseconds != UINT64_MAX) {
                     result = pthread_cond_timedwait(&wfmo->CVariable, &wfmo->Mutex, &ts);
                 } else {
                     result = pthread_cond_wait(&wfmo->CVariable, &wfmo->Mutex);
@@ -513,7 +513,7 @@ namespace neosmart {
         HANDLE handle = static_cast<HANDLE>(event);
 
         // WaitForSingleObject(Ex) and WaitForMultipleObjects(Ex) only support 32-bit timeout
-        if (milliseconds == -1ul || (milliseconds >> 32) == 0) {
+        if (milliseconds == UINT64_MAX || (milliseconds >> 32) == 0) {
             result = WaitForSingleObject(handle, static_cast<uint32_t>(milliseconds));
         } else {
             // Cannot wait for 0xFFFFFFFF because that means infinity to WIN32
@@ -562,7 +562,7 @@ namespace neosmart {
         uint32_t result = 0;
 
         // WaitForSingleObject(Ex) and WaitForMultipleObjects(Ex) only support 32-bit timeout
-        if (milliseconds == -1ul || (milliseconds >> 32) == 0) {
+        if (milliseconds == UINT64_MAX || (milliseconds >> 32) == 0) {
             result = WaitForMultipleObjects(count, handles, waitAll,
                                             static_cast<uint32_t>(milliseconds));
         } else {

--- a/src/pevents.h
+++ b/src/pevents.h
@@ -22,10 +22,13 @@ namespace neosmart {
     struct neosmart_event_t_;
     typedef neosmart_event_t_ *neosmart_event_t;
 
+    // Constant declarations
+    constexpr uint64_t INFINITE_WAIT = ~((unsigned long long)0);
+
     // Function declarations
     neosmart_event_t CreateEvent(bool manualReset = false, bool initialState = false);
     int DestroyEvent(neosmart_event_t event);
-    int WaitForEvent(neosmart_event_t event, uint64_t milliseconds = UINT64_MAX);
+    int WaitForEvent(neosmart_event_t event, uint64_t milliseconds = INFINITE_WAIT);
     int SetEvent(neosmart_event_t event);
     int ResetEvent(neosmart_event_t event);
 #ifdef WFMO

--- a/src/pevents.h
+++ b/src/pevents.h
@@ -25,7 +25,7 @@ namespace neosmart {
     // Function declarations
     neosmart_event_t CreateEvent(bool manualReset = false, bool initialState = false);
     int DestroyEvent(neosmart_event_t event);
-    int WaitForEvent(neosmart_event_t event, uint64_t milliseconds = -1ul);
+    int WaitForEvent(neosmart_event_t event, uint64_t milliseconds = UINT64_MAX);
     int SetEvent(neosmart_event_t event);
     int ResetEvent(neosmart_event_t event);
 #ifdef WFMO


### PR DESCRIPTION
C4146 happens when you assign a unary minus operator to an unsigned
type -(1ul). Proposed PR changes -1ul to UINT64_MAX to be explicit
about comparisons and avoid C4146 warning.