### PR TITLE
Fix warning Wshorten64-32 loss of integer precision

### DIFF
--- a/src/pevents.cpp
+++ b/src/pevents.cpp
@@ -127,7 +127,7 @@ namespace neosmart {
                 uint64_t nanoseconds = ((uint64_t)tv.tv_sec) * 1000 * 1000 * 1000 +
                                        milliseconds * 1000 * 1000 + ((uint64_t)tv.tv_usec) * 1000;
 
-                ts.tv_sec = (long) (nanoseconds / 1000 / 1000 / 1000);
+                ts.tv_sec = (time_t) (nanoseconds / 1000 / 1000 / 1000);
                 ts.tv_nsec = (long) (nanoseconds - ((uint64_t)ts.tv_sec) * 1000 * 1000 * 1000);
             }
 
@@ -271,7 +271,7 @@ namespace neosmart {
                 uint64_t nanoseconds = ((uint64_t)tv.tv_sec) * 1000 * 1000 * 1000 +
                                        milliseconds * 1000 * 1000 + ((uint64_t)tv.tv_usec) * 1000;
 
-                ts.tv_sec = (long) (nanoseconds / 1000 / 1000 / 1000);
+                ts.tv_sec = (time_t) (nanoseconds / 1000 / 1000 / 1000);
                 ts.tv_nsec = (long) (nanoseconds - ((uint64_t)ts.tv_sec) * 1000 * 1000 * 1000);
             }
         }

--- a/src/pevents.cpp
+++ b/src/pevents.cpp
@@ -127,7 +127,7 @@ namespace neosmart {
                 uint64_t nanoseconds = ((uint64_t)tv.tv_sec) * 1000 * 1000 * 1000 +
                                        milliseconds * 1000 * 1000 + ((uint64_t)tv.tv_usec) * 1000;
 
-                ts.tv_sec = nanoseconds / 1000 / 1000 / 1000;
+                ts.tv_sec = (long) (nanoseconds / 1000 / 1000 / 1000);
                 ts.tv_nsec = (long) (nanoseconds - ((uint64_t)ts.tv_sec) * 1000 * 1000 * 1000);
             }
 
@@ -271,7 +271,7 @@ namespace neosmart {
                 uint64_t nanoseconds = ((uint64_t)tv.tv_sec) * 1000 * 1000 * 1000 +
                                        milliseconds * 1000 * 1000 + ((uint64_t)tv.tv_usec) * 1000;
 
-                ts.tv_sec = nanoseconds / 1000 / 1000 / 1000;
+                ts.tv_sec = (long) (nanoseconds / 1000 / 1000 / 1000);
                 ts.tv_nsec = (long) (nanoseconds - ((uint64_t)ts.tv_sec) * 1000 * 1000 * 1000);
             }
         }


### PR DESCRIPTION
We compile pevents with strict warnings including -Wshorten64-32.

On my system where long is 32 bits wide and tv_sec is 64 bits wide, this triggers a warning when compiling with flag -Wshorten64-32. To fix this, cast tv_sec to time_t.