### PR TITLE
RFC: Rename neosmart_event_t to pevent_t

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,23 +60,23 @@ correct¹.
 Linux, and a common pitfall for developers coming from the Windows world.*
 
 ```cpp
-neosmart_event_t CreateEvent(bool manualReset, bool initialState);
+pthread_event_t CreateEvent(bool manualReset, bool initialState);
 
-int DestroyEvent(neosmart_event_t event);
+int DestroyEvent(pthread_event_t event);
 
-int WaitForEvent(neosmart_event_t event, uint64_t milliseconds);
+int WaitForEvent(pthread_event_t event, uint64_t milliseconds);
 
-int WaitForMultipleEvents(neosmart_event_t *events, int count,
+int WaitForMultipleEvents(pthread_event_t *events, int count,
 		bool waitAll, uint64_t milliseconds);
 
-int WaitForMultipleEvents(neosmart_event_t *events, int count,
+int WaitForMultipleEvents(pthread_event_t *events, int count,
 		bool waitAll, uint64_t milliseconds, int &index);
 
-int SetEvent(neosmart_event_t event);
+int SetEvent(pthread_event_t event);
 
-int ResetEvent(neosmart_event_t event);
+int ResetEvent(pthread_event_t event);
 
-int PulseEvent(neosmart_event_t event);
+int PulseEvent(pthread_event_t event);
 ```
 
 ## Building and using pevents

--- a/README.md
+++ b/README.md
@@ -60,23 +60,23 @@ correct¹.
 Linux, and a common pitfall for developers coming from the Windows world.*
 
 ```cpp
-pthread_event_t CreateEvent(bool manualReset, bool initialState);
+pevent_t CreateEvent(bool manualReset, bool initialState);
 
-int DestroyEvent(pthread_event_t event);
+int DestroyEvent(pevent_t event);
 
-int WaitForEvent(pthread_event_t event, uint64_t milliseconds);
+int WaitForEvent(pevent_t event, uint64_t milliseconds);
 
-int WaitForMultipleEvents(pthread_event_t *events, int count,
+int WaitForMultipleEvents(pevent_t *events, int count,
 		bool waitAll, uint64_t milliseconds);
 
-int WaitForMultipleEvents(pthread_event_t *events, int count,
+int WaitForMultipleEvents(pevent_t *events, int count,
 		bool waitAll, uint64_t milliseconds, int &index);
 
-int SetEvent(pthread_event_t event);
+int SetEvent(pevent_t event);
 
-int ResetEvent(pthread_event_t event);
+int ResetEvent(pevent_t event);
 
-int PulseEvent(pthread_event_t event);
+int PulseEvent(pevent_t event);
 ```
 
 ## Building and using pevents

--- a/examples/sample.cpp
+++ b/examples/sample.cpp
@@ -22,7 +22,7 @@
 using namespace neosmart;
 using namespace std;
 
-neosmart_event_t events[5];           // letters, numbers, abort, letterSync, numberSync
+pthread_event_t events[5];           // letters, numbers, abort, letterSync, numberSync
 std::atomic<bool> interrupted{false}; // for signal handling
 
 // By leaving these originally unassigned, any access to unitialized memory

--- a/examples/sample.cpp
+++ b/examples/sample.cpp
@@ -22,7 +22,7 @@
 using namespace neosmart;
 using namespace std;
 
-pthread_event_t events[5];           // letters, numbers, abort, letterSync, numberSync
+pevent_t events[5];           // letters, numbers, abort, letterSync, numberSync
 std::atomic<bool> interrupted{false}; // for signal handling
 
 // By leaving these originally unassigned, any access to unitialized memory

--- a/src/pevents.cpp
+++ b/src/pevents.cpp
@@ -50,7 +50,7 @@ namespace neosmart {
 #endif // WFMO
 
     // The basic event structure, passed to the caller as an opaque pointer when creating events
-    struct neosmart_event_t_ {
+    struct pthread_event_t_ {
         pthread_cond_t CVariable;
         pthread_mutex_t Mutex;
         bool AutoReset;
@@ -91,8 +91,8 @@ namespace neosmart {
     }
 #endif // WFMO
 
-    neosmart_event_t CreateEvent(bool manualReset, bool initialState) {
-        neosmart_event_t event = new neosmart_event_t_;
+    pthread_event_t CreateEvent(bool manualReset, bool initialState) {
+        pthread_event_t event = new pthread_event_t_;
 
         int result = pthread_cond_init(&event->CVariable, 0);
         assert(result == 0);
@@ -111,7 +111,7 @@ namespace neosmart {
         return event;
     }
 
-    static int UnlockedWaitForEvent(neosmart_event_t event, uint64_t milliseconds) {
+    static int UnlockedWaitForEvent(pthread_event_t event, uint64_t milliseconds) {
         int result = 0;
         if (!event->State) {
             // Zero-timeout event state check optimization
@@ -157,7 +157,7 @@ namespace neosmart {
         return result;
     }
 
-    int WaitForEvent(neosmart_event_t event, uint64_t milliseconds) {
+    int WaitForEvent(pthread_event_t event, uint64_t milliseconds) {
         int tempResult;
         if (milliseconds == 0) {
             tempResult = pthread_mutex_trylock(&event->Mutex);
@@ -179,13 +179,13 @@ namespace neosmart {
     }
 
 #ifdef WFMO
-    int WaitForMultipleEvents(neosmart_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
                               uint64_t milliseconds) {
         int unused;
         return WaitForMultipleEvents(events, count, waitAll, milliseconds, unused);
     }
 
-    int WaitForMultipleEvents(neosmart_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
                               uint64_t milliseconds, int &waitIndex) {
         neosmart_wfmo_t wfmo = new neosmart_wfmo_t_;
 
@@ -315,7 +315,7 @@ namespace neosmart {
     }
 #endif // WFMO
 
-    int DestroyEvent(neosmart_event_t event) {
+    int DestroyEvent(pthread_event_t event) {
         int result = 0;
 
 #ifdef WFMO
@@ -340,7 +340,7 @@ namespace neosmart {
         return 0;
     }
 
-    int SetEvent(neosmart_event_t event) {
+    int SetEvent(pthread_event_t event) {
         int result = pthread_mutex_lock(&event->Mutex);
         assert(result == 0);
 
@@ -459,7 +459,7 @@ namespace neosmart {
         return 0;
     }
 
-    int ResetEvent(neosmart_event_t event) {
+    int ResetEvent(pthread_event_t event) {
         int result = pthread_mutex_lock(&event->Mutex);
         assert(result == 0);
 
@@ -472,7 +472,7 @@ namespace neosmart {
     }
 
 #ifdef PULSE
-    int PulseEvent(neosmart_event_t event) {
+    int PulseEvent(pthread_event_t event) {
         // This may look like it's a horribly inefficient kludge with the sole intention of reducing
         // code duplication, but in reality this is what any PulseEvent() implementation must look
         // like. The only overhead (function calls aside, which your compiler will likely optimize
@@ -499,16 +499,16 @@ namespace neosmart {
 #include "pevents.h"
 
 namespace neosmart {
-    neosmart_event_t CreateEvent(bool manualReset, bool initialState) {
-        return static_cast<neosmart_event_t>(::CreateEvent(NULL, manualReset, initialState, NULL));
+    pthread_event_t CreateEvent(bool manualReset, bool initialState) {
+        return static_cast<pthread_event_t>(::CreateEvent(NULL, manualReset, initialState, NULL));
     }
 
-    int DestroyEvent(neosmart_event_t event) {
+    int DestroyEvent(pthread_event_t event) {
         HANDLE handle = static_cast<HANDLE>(event);
         return CloseHandle(handle) ? 0 : GetLastError();
     }
 
-    int WaitForEvent(neosmart_event_t event, uint64_t milliseconds) {
+    int WaitForEvent(pthread_event_t event, uint64_t milliseconds) {
         uint32_t result = 0;
         HANDLE handle = static_cast<HANDLE>(event);
 
@@ -539,24 +539,24 @@ namespace neosmart {
         return GetLastError();
     }
 
-    int SetEvent(neosmart_event_t event) {
+    int SetEvent(pthread_event_t event) {
         HANDLE handle = static_cast<HANDLE>(event);
         return ::SetEvent(handle) ? 0 : GetLastError();
     }
 
-    int ResetEvent(neosmart_event_t event) {
+    int ResetEvent(pthread_event_t event) {
         HANDLE handle = static_cast<HANDLE>(event);
         return ::ResetEvent(handle) ? 0 : GetLastError();
     }
 
 #ifdef WFMO
-    int WaitForMultipleEvents(neosmart_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
                               uint64_t milliseconds) {
         int index = 0;
         return WaitForMultipleEvents(events, count, waitAll, milliseconds, index);
     }
 
-    int WaitForMultipleEvents(neosmart_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
                               uint64_t milliseconds, int &index) {
         HANDLE *handles = reinterpret_cast<HANDLE *>(events);
         uint32_t result = 0;
@@ -593,7 +593,7 @@ namespace neosmart {
 #endif
 
 #ifdef PULSE
-    int PulseEvent(neosmart_event_t event) {
+    int PulseEvent(pthread_event_t event) {
         HANDLE handle = static_cast<HANDLE>(event);
         return ::PulseEvent(handle) ? 0 : GetLastError();
     }

--- a/src/pevents.cpp
+++ b/src/pevents.cpp
@@ -50,7 +50,7 @@ namespace neosmart {
 #endif // WFMO
 
     // The basic event structure, passed to the caller as an opaque pointer when creating events
-    struct pthread_event_t_ {
+    struct pevent_t_ {
         pthread_cond_t CVariable;
         pthread_mutex_t Mutex;
         bool AutoReset;
@@ -91,8 +91,8 @@ namespace neosmart {
     }
 #endif // WFMO
 
-    pthread_event_t CreateEvent(bool manualReset, bool initialState) {
-        pthread_event_t event = new pthread_event_t_;
+    pevent_t CreateEvent(bool manualReset, bool initialState) {
+        pevent_t event = new pevent_t_;
 
         int result = pthread_cond_init(&event->CVariable, 0);
         assert(result == 0);
@@ -111,7 +111,7 @@ namespace neosmart {
         return event;
     }
 
-    static int UnlockedWaitForEvent(pthread_event_t event, uint64_t milliseconds) {
+    static int UnlockedWaitForEvent(pevent_t event, uint64_t milliseconds) {
         int result = 0;
         if (!event->State) {
             // Zero-timeout event state check optimization
@@ -157,7 +157,7 @@ namespace neosmart {
         return result;
     }
 
-    int WaitForEvent(pthread_event_t event, uint64_t milliseconds) {
+    int WaitForEvent(pevent_t event, uint64_t milliseconds) {
         int tempResult;
         if (milliseconds == 0) {
             tempResult = pthread_mutex_trylock(&event->Mutex);
@@ -179,13 +179,13 @@ namespace neosmart {
     }
 
 #ifdef WFMO
-    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pevent_t *events, int count, bool waitAll,
                               uint64_t milliseconds) {
         int unused;
         return WaitForMultipleEvents(events, count, waitAll, milliseconds, unused);
     }
 
-    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pevent_t *events, int count, bool waitAll,
                               uint64_t milliseconds, int &waitIndex) {
         neosmart_wfmo_t wfmo = new neosmart_wfmo_t_;
 
@@ -315,7 +315,7 @@ namespace neosmart {
     }
 #endif // WFMO
 
-    int DestroyEvent(pthread_event_t event) {
+    int DestroyEvent(pevent_t event) {
         int result = 0;
 
 #ifdef WFMO
@@ -340,7 +340,7 @@ namespace neosmart {
         return 0;
     }
 
-    int SetEvent(pthread_event_t event) {
+    int SetEvent(pevent_t event) {
         int result = pthread_mutex_lock(&event->Mutex);
         assert(result == 0);
 
@@ -459,7 +459,7 @@ namespace neosmart {
         return 0;
     }
 
-    int ResetEvent(pthread_event_t event) {
+    int ResetEvent(pevent_t event) {
         int result = pthread_mutex_lock(&event->Mutex);
         assert(result == 0);
 
@@ -472,7 +472,7 @@ namespace neosmart {
     }
 
 #ifdef PULSE
-    int PulseEvent(pthread_event_t event) {
+    int PulseEvent(pevent_t event) {
         // This may look like it's a horribly inefficient kludge with the sole intention of reducing
         // code duplication, but in reality this is what any PulseEvent() implementation must look
         // like. The only overhead (function calls aside, which your compiler will likely optimize
@@ -499,16 +499,16 @@ namespace neosmart {
 #include "pevents.h"
 
 namespace neosmart {
-    pthread_event_t CreateEvent(bool manualReset, bool initialState) {
-        return static_cast<pthread_event_t>(::CreateEvent(NULL, manualReset, initialState, NULL));
+    pevent_t CreateEvent(bool manualReset, bool initialState) {
+        return static_cast<pevent_t>(::CreateEvent(NULL, manualReset, initialState, NULL));
     }
 
-    int DestroyEvent(pthread_event_t event) {
+    int DestroyEvent(pevent_t event) {
         HANDLE handle = static_cast<HANDLE>(event);
         return CloseHandle(handle) ? 0 : GetLastError();
     }
 
-    int WaitForEvent(pthread_event_t event, uint64_t milliseconds) {
+    int WaitForEvent(pevent_t event, uint64_t milliseconds) {
         uint32_t result = 0;
         HANDLE handle = static_cast<HANDLE>(event);
 
@@ -539,24 +539,24 @@ namespace neosmart {
         return GetLastError();
     }
 
-    int SetEvent(pthread_event_t event) {
+    int SetEvent(pevent_t event) {
         HANDLE handle = static_cast<HANDLE>(event);
         return ::SetEvent(handle) ? 0 : GetLastError();
     }
 
-    int ResetEvent(pthread_event_t event) {
+    int ResetEvent(pevent_t event) {
         HANDLE handle = static_cast<HANDLE>(event);
         return ::ResetEvent(handle) ? 0 : GetLastError();
     }
 
 #ifdef WFMO
-    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pevent_t *events, int count, bool waitAll,
                               uint64_t milliseconds) {
         int index = 0;
         return WaitForMultipleEvents(events, count, waitAll, milliseconds, index);
     }
 
-    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pevent_t *events, int count, bool waitAll,
                               uint64_t milliseconds, int &index) {
         HANDLE *handles = reinterpret_cast<HANDLE *>(events);
         uint32_t result = 0;
@@ -593,7 +593,7 @@ namespace neosmart {
 #endif
 
 #ifdef PULSE
-    int PulseEvent(pthread_event_t event) {
+    int PulseEvent(pevent_t event) {
         HANDLE handle = static_cast<HANDLE>(event);
         return ::PulseEvent(handle) ? 0 : GetLastError();
     }

--- a/src/pevents.h
+++ b/src/pevents.h
@@ -19,25 +19,25 @@
 
 namespace neosmart {
     // Type declarations
-    struct pthread_event_t_;
-    typedef pthread_event_t_ *pthread_event_t;
+    struct pevent_t_;
+    typedef pevent_t_ *pevent_t;
 
     // Constant declarations
     const uint64_t WAIT_INFINITE = ~((unsigned long long)0);
 
     // Function declarations
-    pthread_event_t CreateEvent(bool manualReset = false, bool initialState = false);
-    int DestroyEvent(pthread_event_t event);
-    int WaitForEvent(pthread_event_t event, uint64_t milliseconds = WAIT_INFINITE);
-    int SetEvent(pthread_event_t event);
-    int ResetEvent(pthread_event_t event);
+    pevent_t CreateEvent(bool manualReset = false, bool initialState = false);
+    int DestroyEvent(pevent_t event);
+    int WaitForEvent(pevent_t event, uint64_t milliseconds = WAIT_INFINITE);
+    int SetEvent(pevent_t event);
+    int ResetEvent(pevent_t event);
 #ifdef WFMO
-    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pevent_t *events, int count, bool waitAll,
                               uint64_t milliseconds);
-    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pevent_t *events, int count, bool waitAll,
                               uint64_t milliseconds, int &index);
 #endif
 #ifdef PULSE
-    int PulseEvent(pthread_event_t event);
+    int PulseEvent(pevent_t event);
 #endif
 } // namespace neosmart

--- a/src/pevents.h
+++ b/src/pevents.h
@@ -19,25 +19,25 @@
 
 namespace neosmart {
     // Type declarations
-    struct neosmart_event_t_;
-    typedef neosmart_event_t_ *neosmart_event_t;
+    struct pthread_event_t_;
+    typedef pthread_event_t_ *pthread_event_t;
 
     // Constant declarations
     const uint64_t WAIT_INFINITE = ~((unsigned long long)0);
 
     // Function declarations
-    neosmart_event_t CreateEvent(bool manualReset = false, bool initialState = false);
-    int DestroyEvent(neosmart_event_t event);
-    int WaitForEvent(neosmart_event_t event, uint64_t milliseconds = WAIT_INFINITE);
-    int SetEvent(neosmart_event_t event);
-    int ResetEvent(neosmart_event_t event);
+    pthread_event_t CreateEvent(bool manualReset = false, bool initialState = false);
+    int DestroyEvent(pthread_event_t event);
+    int WaitForEvent(pthread_event_t event, uint64_t milliseconds = WAIT_INFINITE);
+    int SetEvent(pthread_event_t event);
+    int ResetEvent(pthread_event_t event);
 #ifdef WFMO
-    int WaitForMultipleEvents(neosmart_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
                               uint64_t milliseconds);
-    int WaitForMultipleEvents(neosmart_event_t *events, int count, bool waitAll,
+    int WaitForMultipleEvents(pthread_event_t *events, int count, bool waitAll,
                               uint64_t milliseconds, int &index);
 #endif
 #ifdef PULSE
-    int PulseEvent(neosmart_event_t event);
+    int PulseEvent(pthread_event_t event);
 #endif
 } // namespace neosmart

--- a/tests/AutoResetBasicTests.cpp
+++ b/tests/AutoResetBasicTests.cpp
@@ -7,9 +7,9 @@
 
 using namespace neosmart;
 
-pthread_event_t event;
-pthread_event_t t1_started;
-pthread_event_t t1_finished;
+pevent_t event;
+pevent_t t1_started;
+pevent_t t1_finished;
 
 void worker() {
     WaitForEvent(event, 0);

--- a/tests/AutoResetBasicTests.cpp
+++ b/tests/AutoResetBasicTests.cpp
@@ -7,9 +7,9 @@
 
 using namespace neosmart;
 
-neosmart_event_t event;
-neosmart_event_t t1_started;
-neosmart_event_t t1_finished;
+pthread_event_t event;
+pthread_event_t t1_started;
+pthread_event_t t1_finished;
 
 void worker() {
     WaitForEvent(event, 0);

--- a/tests/ManualResetBasicTests.cpp
+++ b/tests/ManualResetBasicTests.cpp
@@ -7,9 +7,9 @@
 
 using namespace neosmart;
 
-pthread_event_t event;
-pthread_event_t t1_started;
-pthread_event_t t1_finished;
+pevent_t event;
+pevent_t t1_started;
+pevent_t t1_finished;
 
 void worker() {
     WaitForEvent(event, 0);

--- a/tests/ManualResetBasicTests.cpp
+++ b/tests/ManualResetBasicTests.cpp
@@ -7,9 +7,9 @@
 
 using namespace neosmart;
 
-neosmart_event_t event;
-neosmart_event_t t1_started;
-neosmart_event_t t1_finished;
+pthread_event_t event;
+pthread_event_t t1_started;
+pthread_event_t t1_finished;
 
 void worker() {
     WaitForEvent(event, 0);

--- a/tests/WaitTimeoutAllSignalled.cpp
+++ b/tests/WaitTimeoutAllSignalled.cpp
@@ -5,7 +5,7 @@
 #include "pevents.h"
 
 int main() {
-    std::vector<neosmart::pthread_event_t> lPEvents(63); // Can be any number of events from 1-N.
+    std::vector<neosmart::pevent_t> lPEvents(63); // Can be any number of events from 1-N.
     for (auto &lEvent : lPEvents) {
         // Manual or Auto-Reset Events (doesn't matter which kind), and all already set.
         //

--- a/tests/WaitTimeoutAllSignalled.cpp
+++ b/tests/WaitTimeoutAllSignalled.cpp
@@ -5,7 +5,7 @@
 #include "pevents.h"
 
 int main() {
-    std::vector<neosmart::neosmart_event_t> lPEvents(63); // Can be any number of events from 1-N.
+    std::vector<neosmart::pthread_event_t> lPEvents(63); // Can be any number of events from 1-N.
     for (auto &lEvent : lPEvents) {
         // Manual or Auto-Reset Events (doesn't matter which kind), and all already set.
         //


### PR DESCRIPTION
I'm opening this as a request for comments in case anyone has any feedback before squash-merging the commits in this PR into the `master` branch.

The rationale for using `pevent_t` instead of the previous `neosmart_event_t` or the other option of `pthread_event_t` (which is *probably* the "classiest" option) is described in the commit messages:

> The original name was an attempt to keep with the naming conventions
used by the pthreads library, along the lines of `libname_objname_t`.
However, it doesn't seem necessary or proper to do so if we are using
C++ with the code in the `neosmart` namespace.
>
> It also doesn't seem correct to use `pthread_event_t` as the name if the
event object is not part of the `pthread` library proper, even if it is
built atop of it. Furthermore, there's no need for the name to be so
long and wordy if we have the advantage of C++ namespacing, since
there's no risk of a name collision.