### PR TITLE
Fix a warning which is treated as en error in Clang

### DIFF
--- a/src/pevents.cpp
+++ b/src/pevents.cpp
@@ -517,7 +517,7 @@ namespace neosmart {
             result = WaitForSingleObject(handle, static_cast<uint32_t>(milliseconds));
         } else {
             // Cannot wait for 0xFFFFFFFF because that means infinity to WIN32
-            uint32_t waitUnit = (WAIT_INFINITE - 1);
+            uint32_t waitUnit = static_cast<uint32_t>(WAIT_INFINITE - 1);
             uint64_t rounds = milliseconds / waitUnit;
             uint32_t remainder = milliseconds % waitUnit;
 


### PR DESCRIPTION
I'm a dev from Microsoft and our product dependents on pevent. Recent changes will bring a warning and this warning in Clang is treated as an error:

uint32_t waitUnit = (WAIT_INFINITE - 1); 

\deps\pevents\src\pevents.cpp(520,48): error : implicit conversion from 'unsigned long long' to 'uint32_t' (aka 'unsigned int') changes value from 18446744073709551614 to 4294967294 [-Werror,-Wconstant-conversion] [C:\MSAL3\microsoft-authentication-library-for-cpp\_builds\vs-16-2019-win64-llvm-cxx17\source\msalsdk.vcxproj]