### PR TITLE
Remove homebrew usage in macOS CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install python3 ninja
-          sudo pip3 install meson
+          sudo pip3 install meson ninja
 
       - name: meson build
         run: |


### PR DESCRIPTION
The GitHub documentation for the macOS virtual environment says python3
and pip3 are already installed [1], so eliminate homebrew usage because
a) homebrew is slow as molasses, and b) we don't like or support its
developers for the backwards stance they've taken on many issues.

[1]: https://github.com/actions/virtual-environments/blob/macOS-10.15/20210213.1/images/macos/macos-10.15-Readme.md