### PR TITLE
Drop zero-timeout pthread_mutex_trylock() optimization

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ basic_tests = ['ManualResetInitialState',
 		'AutoResetInitialState',
 		'ManualResetBasicTests',
 		'AutoResetBasicTests',
+		'EventContention',
 	]
 # Tests that required wfmo
 wfmo_tests = [

--- a/tests/EventContention.cpp
+++ b/tests/EventContention.cpp
@@ -1,0 +1,39 @@
+// This tests contention on an auto-reset event that is always available at a high level, to verify
+// that other threads acquiring the protective pthread mutex don't result in a spurious WAIT_TIMEOUT
+// error for any `WaitForEvent()` callers.
+//
+// See https://github.com/neosmart/pevents/issues/18
+
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+#include <cassert>
+#include <iostream>
+#include <pevents.h>
+#include <thread>
+
+using namespace neosmart;
+
+int main() {
+    // Create an auto-reset event that is initially signalled
+    neosmart_event_t event = CreateEvent(false, true);
+
+
+    // Create n threads to constantly call SetEvent() in a tight loop
+    for (int i = 0; i < 16; ++i) {
+        std::thread t1([&] {
+            SetEvent(event);
+        });
+        t1.detach();
+    }
+
+    // Call WaitForEvent() in a tight loop; we can expect it to always be available.
+    for (int i = 0; i < 200000; ++i) {
+        int result = WaitForEvent(event, 0);
+        assert(result == 0);
+        // Guarantee this thread always calls `WaitForEvent()` on a signalled event
+        SetEvent(event);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Previously, if the mutex protecting the inner state of the event object
were locked by another thread, the early abort in `WaitForEvent()` with
a zero-ms timeout would have translated that to a `WAIT_TIMEOUT` result,
even if the application logic is such that the event in question is
always set (e.g. simultaneous calls to `WaitForEvent()` and `SetEvent()`
on an already-set event).

This patch makes `event->State` an atomic that can be used as a
synchronization point (currently in addition to rather than instead of
`event->Mutex`).

Note: Unlocking the spinlock (i.e. resetting the event) is done with
release semantics rather than using `std::memory_order_relaxed` due to
ambiguities in the C++ spec that make it unclear whether or not
consecutive Set/Reset blocks could be interleaved with the latter; see
the discussion preceding [0] for reference.

Closes #18.

[0]: https://old.reddit.com/r/cpp/comments/g84bzv/c/fpua2yq/