### PR TITLE
Make `WaitForMultipleEvents` atomic when `waitAll` is true

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ basic_tests = ['ManualResetInitialState',
 # Tests that required wfmo
 wfmo_tests = [
     'WaitTimeoutAllSignalled',
+    'AtomicWaitAll',
   ]
 
 test_std = 'c++11'

--- a/src/pevents.cpp
+++ b/src/pevents.cpp
@@ -14,7 +14,6 @@
 #include <memory>
 #include <pthread.h>
 #include <sys/time.h>
-#include <vector>
 #ifdef WFMO
 #include <algorithm>
 #include <deque>

--- a/src/pevents.cpp
+++ b/src/pevents.cpp
@@ -294,8 +294,7 @@ namespace neosmart {
 
         if (waitAll) {
             // Decrement EventsLeft in one go to avoid cache line pressure.
-            int left = wfmo->Status.EventsLeft.fetch_sub(events_skipped, std::memory_order_acq_rel);
-            assert(left > 0);
+            wfmo->Status.EventsLeft.fetch_sub(events_skipped, std::memory_order_acq_rel);
         }
 
         timespec ts;

--- a/tests/AtomicWaitAll.cpp
+++ b/tests/AtomicWaitAll.cpp
@@ -1,0 +1,45 @@
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include <pevents.h>
+#include <thread>
+
+using namespace neosmart;
+
+int main() {
+    neosmart::neosmart_event_t lEvents[3];
+    lEvents[0] = neosmart::CreateEvent( false, true );  // Already Signaled AutoReset
+    lEvents[1] = neosmart::CreateEvent( false, false ); // Not Signaled AutoReset
+    lEvents[2] = neosmart::CreateEvent( false, true );  // Already Signaled AutoReset
+
+    // WFMO is non-destructive if a wait-all with any timeout value fails on auto-reset events.
+    if ( neosmart::WaitForMultipleEvents( lEvents, 3, true, 0 ) == 0 )
+        throw std::runtime_error( "Must not be signaled!" );
+
+    // FAILS!!
+    if ( neosmart::WaitForEvent( lEvents[0], 0 ) != 0 )
+        throw std::runtime_error( "Must be signaled" );
+
+    if ( neosmart::WaitForEvent( lEvents[1], 0 ) != WAIT_TIMEOUT )
+        throw std::runtime_error( "Must not be signaled" );
+
+    // FAILS!!
+    if ( neosmart::WaitForEvent( lEvents[2], 0 ) != 0 )
+        throw std::runtime_error( "Must be signaled" );
+
+
+    // WFMO is destructive if a wait-all succeeds with any timeout value on auto-reset events.
+    for ( auto& lEvent : lEvents )
+        neosmart::SetEvent( lEvent );
+    if ( neosmart::WaitForMultipleEvents( lEvents, 3, true, 0 ) != 0 )  // OK
+        throw std::runtime_error( "Must be signaled!" );
+    for ( auto& lEvent : lEvents )
+    {
+        if ( neosmart::WaitForEvent( lEvent, 0 ) != WAIT_TIMEOUT ) // OK
+            throw std::runtime_error( "Must not be signaled" );
+        neosmart::DestroyEvent( lEvent );
+    }
+}


### PR DESCRIPTION
This patch significantly changes the behavior (and to an extent, the
performance) of pevents to more closely mimic the documented behavior of
`WaitForMultipleObjects` and `WaitForMultipleObjectsEx`.

As reported in #9, the previous behavior did not make any atomicity
guarantees when a call to `WaitForMultipleEvents()` was made with
`waitAll = true`, and WFME would attempt to serially obtain the events
in question, which could lead to a deadlock in case of circular locking
and auto-reset events.

The WFMO behavior documented on MSDN makes it clear that the Windows
implementation does not modify the signalled state of any of the manual
or auto reset events being awaited until the WFMO call is ready to
return, at which point either the one event in question or all the
events being awaited (dependent on `waitAll`) are atomically awaited.

Closes #9
